### PR TITLE
feat: Agregar volumen montado 'uploads' al contenedor web

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     ports:
       - "8080:80"
     volumes:
+      - ./uploads:/home/uploads
       - ./app:/var/www/html
     environment:
       MYSQL_ROOT_PASSWORD: "${DB_ROOT_PASS}"

--- a/uploads/README.md
+++ b/uploads/README.md
@@ -1,0 +1,1 @@
+Este archivo existe para que el directorio Uploads se pueda subir al repositorio.


### PR DESCRIPTION
- Montar ./uploads en /home/uploads dentro del contenedor
- Agregar README.md en uploads para mantener el directorio en el repo
- uploads se usara para guardar los archivos que se deban subir al sistema por ejemplo los Flyers