### PR TITLE
Modulo-8 refactor / corrección de defectos revisión de pares CU_08

### DIFF
--- a/app/CU_08_Reporte_Alumnado/obtener_catalogos.php
+++ b/app/CU_08_Reporte_Alumnado/obtener_catalogos.php
@@ -1,4 +1,22 @@
 <?php
+/*
+  Archivo     : obtener_catalogos.php
+  Módulo      : CU_08_Reporte_Alumnado
+  Autor       : Alejandro Resendiz Reyes
+  Fecha       : 15/03/2026		
+  Descripción : Este archivo se encarga de 
+  				obtener los catálogos necesarios 
+				para el reporte de alumnado, 
+				específicamente los servicios 
+				disponibles y los estados de 
+				los alumnos. Se conecta a la 
+				base de datos, ejecuta las consultas
+				necesarias y devuelve los resultados
+				en formato JSON para ser utilizados
+				en el frontend del módulo.
+
+*/
+
 require_once '../php/db.php';
 
 try{

--- a/app/CU_08_Reporte_Alumnado/reporte_alumnos.html
+++ b/app/CU_08_Reporte_Alumnado/reporte_alumnos.html
@@ -1,3 +1,16 @@
+<!--
+
+  Archivo     : reporte_alumnos.html
+  Módulo      : CU_08_Reporte_Alumnado
+  Autor       : Alejandro Resendiz Reyes
+  Fecha       : 15/03/2026		
+  Descripción : Interfaz para generar reportes de alumnos inscritos en actividades, 
+  				con opciones de filtrado por actividad y estado, 
+				y exportación a Excel y PDF.
+
+
+-->
+
 <!DOCTYPE html>
 <html lang="es">
 	<head>
@@ -35,7 +48,7 @@
 					<option value ="TODOS">--Todas--</option>
 				</select>
 				<div class="buttons-group">
-					<button onClick="cargar_tabla()" id="btnGenerarTabla">Generar Tabla</button>
+					<button onClick="renderTablaReporte()" id="btnGenerarTabla">Generar Tabla</button>
 					<button onClick="exportarExcel()" id="btnGenerarExcel" style="visibility: hidden">Generar Excel</button>
 					<button onClick="imprimirPDF()" id="btnGenerarPDF" style="visibility: hidden">Generar PDF</button>
 				</div>	

--- a/app/CU_08_Reporte_Alumnado/reporte_alumnos.js
+++ b/app/CU_08_Reporte_Alumnado/reporte_alumnos.js
@@ -1,10 +1,23 @@
+/*
+  Archivo     : reporte_alumnos.js
+  Módulo      : CU_08_Reporte_Alumnado
+  Autor       : Alejandro Resendiz Reyes
+  Fecha       : 15/03/2026		
+  Descripción : Archivo JS para el reporte de alumnos, 
+					se encarga de cargar los catalogos para los select, 
+				cargar la tabla con los filtros seleccionados por el 
+				usuario y exportar la tabla a Excel o PDF.
+
+*/
+
+
 import { obtenerCookie } from '../js/cookie.js';
 import { renderMenu } from '../js/menu.js';
 
 
-window.cargar_tabla=cargar_tabla;
-window.exportarExcel=exportarExcel;
-window.imprimirPDF=imprimirPDF;
+window.renderTablaReporte = renderTablaReporte;
+window.exportarExcel = exportarExcel;
+window.imprimirPDF = imprimirPDF;
 /*
  * Al cargar la página se revisa que el usuario tenga una sesión iniciada
  * Posterior a tener una sesión iniciada se cargan los catalogos para los
@@ -12,7 +25,7 @@ window.imprimirPDF=imprimirPDF;
  */
 
 
-document.addEventListener("DOMContentLoaded", function(){
+document.addEventListener("DOMContentLoaded", function () {
 	const tipoUsuario = obtenerCookie('Id_tipo_usuario');
 	if (tipoUsuario == '2') {
 		const tipoUsuario = obtenerCookie('Id_tipo_usuario');
@@ -27,8 +40,8 @@ document.addEventListener("DOMContentLoaded", function(){
 /*
  * Si no hay cookies, se redirige al inicio de sesión automaticamente.
  */
-function redireccionar(){
-	if(!document.cookie){
+function redireccionar() {
+	if (!document.cookie) {
 		window.location.href = "../CU_01_Login/login.html";
 	}
 }
@@ -38,29 +51,29 @@ function redireccionar(){
  * CARGAR CATALOGOS EN LOS SELECT
  */
 
-function cargar_catalogos(){
+function cargar_catalogos() {
 	fetch("./obtener_catalogos.php")
-		.then(function (respuesta){
+		.then(function (respuesta) {
 			return respuesta.json();
 		})
-		.then(function(catalogos){
-			catalogos.servicios.forEach(function (servicio){
+		.then(function (catalogos) {
+			catalogos.servicios.forEach(function (servicio) {
 				//Se crea una opción con value como el Id_servicio de la actividad a cargar
 				const option = document.createElement('option');
 				option.value = servicio.Id_servicio;
 				//A la opción se le da el texto de Servicio (nombre del servicio)
 				option.textContent = servicio.Servicio;
 				document.getElementById('actividad').appendChild(option)
-			});	
-			catalogos.estados.forEach(function (estado){
+			});
+			catalogos.estados.forEach(function (estado) {
 				// Se cargan los estados disponibles que puede tener un servicio.
 				// PENDIENTE, EN_CURSO, COMPLETADO
 				const option = document.createElement('option');
 				option.value = estado.Estado;
 				option.textContent = estado.Estado;
 				document.getElementById('estado').appendChild(option)
-			});	
-		});	
+			});
+		});
 }
 
 
@@ -68,81 +81,84 @@ function cargar_catalogos(){
  * CARGAR TABLA
  */
 
-function cargar_tabla(){
+function renderTablaReporte() {
 
 	// Se cargan los elemento a usar desde el HTML
-	const actividad = document.getElementById("actividad").value;
-	const estado = document.getElementById("estado").value;
-	const titulos = document.getElementById("Titulos");
-	const tabla = document.getElementById("Tabla");
-	const bExcel = document.getElementById("btnGenerarExcel");
-	const bPDF = document.getElementById("btnGenerarPDF");
+	const elActividad = document.getElementById("actividad").value;
+	const elEstado = document.getElementById("estado").value;
+	const elTitulos = document.getElementById("Titulos");
+	const elTabla = document.getElementById("Tabla");
+	const elBtnExcel = document.getElementById("btnGenerarExcel");
+	const elBtnPDF = document.getElementById("btnGenerarPDF");
 	// Se limpian las tablas de caulquier contenido que tengan
-	titulos.innerHTML=""
-	tabla.innerHTML="";
+	elTitulos.innerHTML = ""
+	elTabla.innerHTML = "";
 
 
-	fetch("./reporte_alumnos.php",{
+	fetch("./reporte_alumnos.php", {
 		method: "POST",
-		headers:{
-			"Content-Type":"application/json"
+		headers: {
+			"Content-Type": "application/json"
 		},
 		// Se cargan los filtros seleccionado por el usuario
-		body: JSON.stringify({ actividad: actividad, estado:estado})
+		body: JSON.stringify({ actividad: elActividad, estado: elEstado })
 		// No es necesario enviar el Id_usuario o Id_carrera porque ese se obtiene dentro del php
-	}) 
-		.then(function (respuesta){
+	})
+		.then(function (respuesta) {
 			//Se obtiene la respuesta del php
 			return respuesta.json();
 		})
-		.then(function (impresion){
+		.then(function (impresion) {
 			//Si la impresión es de tamaño 0 significa que la respuesta es un mensaje
 			//por lo que no se encontraron resultados.
-			if(impresion.length==0){
+			if (impresion.length == 0) {
 				lanzarToast("No se encontraron Resultados", "error");
-				bExcel.style.visibility="hidden";
-				bPDF.style.visibility="hidden";
+				elBtnExcel.style.visibility = "hidden";
+				elBtnPDF.style.visibility = "hidden";
 				return;
 			}
 
 
 			//Renderizado de los titulos obtenidos
-			Object.keys(impresion[0]).forEach(function(titulo){
-				titulos.innerHTML=titulos.innerHTML+"<th>"+titulo+"</th>"
+			Object.keys(impresion[0]).forEach(function (titulo) {
+				elTitulos.innerHTML = elTitulos.innerHTML + "<th>" + titulo + "</th>"
 			});
-			// Renderizado de el contenido de la tabla
-			impresion.forEach(function(fila){
-				//Variable para guardar la fila temporal
-				let table="";
 
-				table=table+"<tr>";
+			// Renderizado de el contenido de la tabla
+			impresion.forEach(function (fila) {
+				//Variable para guardar la fila temporal
+				let htmlFila = "";
+
+				htmlFila = htmlFila + "<tr>";
 				// Por cada titulo (celda) se agrega la celda a la estructura de la fila	
-				Object.keys(fila).forEach(function(dato){
+				Object.keys(fila).forEach(function (dato) {
 					//Se concatena el dato de la fila dentr
-					table=table+"<td>"+fila[dato]+"</td>";
+					htmlFila = htmlFila + "<td>" + fila[dato] + "</td>";
 
 				});
-				table=table+"</tr>";
-				tabla.innerHTML+=table;
+				htmlFila = htmlFila + "</tr>";
+				elTabla.innerHTML += htmlFila;
 			});
 
-			bExcel.style.visibility="visible";
-			bPDF.style.visibility="visible";
+			//Los botones de exportar a Excel y PDF se hacen visibles solo si hay resultados que mostrar,
+			//para evitar generar archivos vacios.
+			elBtnExcel.style.visibility = "visible";
+			elBtnPDF.style.visibility = "visible";
 
 		});
 }
 
-function exportarExcel(){
+function exportarExcel() {
 	event.preventDefault();
-	const workbook=XLSX.utils.table_to_book(document.getElementById('tabla-resultados'));
+	const workbook = XLSX.utils.table_to_book(document.getElementById('tabla-resultados'));
 	XLSX.writeFile(workbook, 'reporte_alumnos.xlsx');
 }
 
-function imprimirPDF(){
+function imprimirPDF() {
 	const { jsPDF } = window.jspdf;
 	const doc = new jsPDF();
 	doc.autoTable({ html: '#tabla-resultados' });
-	doc.save('reporte_alumnos.pdf');	
+	doc.save('reporte_alumnos.pdf');
 }
 function lanzarToast(texto, tipo) {
 	const toast = document.getElementById('toast-mensaje');

--- a/app/CU_08_Reporte_Alumnado/reporte_alumnos.php
+++ b/app/CU_08_Reporte_Alumnado/reporte_alumnos.php
@@ -1,14 +1,29 @@
 <?php
+/*
+  Archivo     : reporte_alumnos.php
+  Módulo      : CU_08_Reporte_Alumnado
+  Autor       : Alejandro Resendiz Reyes
+  Fecha       : 15/03/2026		
+  Descripción : Este archivo se encarga de procesar las solicitudes
+				  para generar el reporte de alumnado. Recibe
+				los filtros seleccionados por el usuario (actividad
+				y estado) a través de una solicitud POST, construye
+				la consulta SQL correspondiente para obtener los datos
+				de los alumnos que cumplen con los criterios especificados,
+				y devuelve los resultados en formato JSON para ser utilizados
+				en el frontend del módulo.
+
+*/
 require_once '../php/db.php';
 
-try{
-	
+try {
+
 	$pdo = new PDO($dsn, $user, $pass, $options);
 
 
-	$valores = json_decode(file_get_contents("php://input"),true);
-	$actividad = $valores['actividad'];
-	$estado = $valores['estado'];
+	$data_filtros = json_decode(file_get_contents("php://input"), true);
+	$actividad = $data_filtros['actividad'];
+	$estado = $data_filtros['estado'];
 
 
 	$query = "SELECT Actividades.Servicio,
@@ -27,26 +42,28 @@ try{
 		JOIN Actividades ON Actividades_Alumnos.Id_servicio=Actividades.Id_servicio 
 		WHERE Administradores.Id_usuario=:Id_usuario 
 		AND Alumnos.Activo=1";
-	
-    		$params = ['Id_usuario' => $_COOKIE['Id_usuario']];
-    
-		// Filtrar por estado (usando 'TODOS' en lugar de '5486')
-		if ($estado !== null && $estado !== 'TODOS') {
-			$query .= " AND Actividades_Alumnos.Estado = :estado";
-			$params['estado'] = $estado;
-		}
-    
-		// Filtrar por actividad
-		if ($actividad !== null && $actividad !== 'TODOS') {
-	        	$query .= " AND Actividades.Id_servicio = :actividad";
-	        	$params['actividad'] = $actividad;
-		}		
-		
-		$consulta = $pdo->prepare($query);
-		$consulta->execute($params);
-		echo json_encode($consulta->fetchAll());
 
-} catch (\PDOException $e){
-    http_response_code(500);
-        echo json_encode(['error' => "Error de conexión: " . $e->getMessage()]);
+	$filtros = ['Id_usuario' => $_COOKIE['Id_usuario']];
+
+	// Filtrar por estado (usando 'TODOS' en lugar de '5486')
+	if ($estado !== null && $estado !== 'TODOS') {
+		$query .= " AND Actividades_Alumnos.Estado = :estado";
+		$filtros['estado'] = $estado;
+	}
+
+	// Filtrar por actividad
+	if ($actividad !== null && $actividad !== 'TODOS') {
+		$query .= " AND Actividades.Id_servicio = :actividad";
+		$filtros['actividad'] = $actividad;
+	}
+
+	$consulta = $pdo->prepare($query);
+
+	$consulta->execute($filtros);
+
+	echo json_encode($consulta->fetchAll());
+
+} catch (\PDOException $e) {
+	http_response_code(500);
+	echo json_encode(['error' => "Error de conexión: " . $e->getMessage()]);
 }


### PR DESCRIPTION
Se corrigieron los defectos encontrados en la revisión de pares del módulo CU_08_Reporte_Alumnado.

Cambios en reporte_alumnos.js:
- Se renombró cargar_tabla() a renderTablaReporte() para reflejar
  correctamente su responsabilidad.
- Se agregaron líneas en blanco entre secciones lógicas dentro del
  segundo bloque .then para mejorar la legibilidad.
- Se renombraron bExcel y bPDF a elBtnExcel y elBtnPDF siguiendo
  el prefijo 'el' establecido en OPSNomenclaturas para referencias al DOM.

Cambios en reporte_alumnos.html:
- Se actualizó el onClick del botón "Generar Tabla" de cargar_tabla()
  a renderTablaReporte() para mantener consistencia con el JS.

Cambios en reporte_alumnos.php:
- Se renombró $params a $filtros y $valores a $data_filtros siguiendo
  las convenciones de nomenclatura del proyecto.
- Se agregaron líneas en blanco entre secciones condicionales del
  bloque de construcción dinámica del query.
  
  
  
  # Pruebas de funcionamiento:
### Carga inicial de la página

- [x] La página carga sin errores en consola
- [x] El menú lateral se renderiza correctamente
- [x] El select de **Actividades** se puebla con los servicios activos de la base de datos
- [x] El select de **Estado** se puebla con los estados existentes (`PENDIENTE`, `EN_CURSO`, `COMPLETADO`, `CANCELADO`)
- [x] Ambos selects muestran `--Todas--` como opción por defecto
- [x] Los botones **Generar Excel** y **Generar PDF** están ocultos al cargar

### Redirección y sesión

- [x] Si no hay cookies activas, redirige automáticamente a `login.html`
- [x] Si el tipo de usuario es `2` (alumno), redirige a `perfil.html`
- [x] Si el tipo de usuario es administrador, permanece en la página

### Generación de tabla

- [x] Al presionar **Generar Tabla** sin filtros muestra todos los alumnos del administrador en sesión
- [x] Al filtrar por una actividad específica, solo aparecen alumnos de esa actividad
- [x] Al filtrar por un estado específico, solo aparecen alumnos con ese estado
- [x] Al filtrar por actividad y estado combinados, el resultado respeta ambos filtros
- [x] Si no hay resultados, aparece el toast con el mensaje `"No se encontraron Resultados"`
- [x] Si no hay resultados, los botones Excel y PDF permanecen ocultos
- [x] Si hay resultados, los encabezados de la tabla se generan correctamente
- [x] Si hay resultados, los datos de cada fila se muestran en las columnas correctas
- [x] Si hay resultados, los botones **Generar Excel** y **Generar PDF** se hacen visibles

### Exportación

- [x] Al presionar **Generar Excel** se descarga el archivo `reporte_alumnos.xlsx`
- [x] El archivo Excel contiene los mismos datos y encabezados que la tabla en pantalla
- [x] Al presionar **Generar PDF** se descarga el archivo `reporte_alumnos.pdf`
- [x] El archivo PDF contiene los mismos datos y encabezados que la tabla en pantalla

### Toast

- [x] El toast de error aparece cuando no hay resultados
- [x] El toast desaparece automáticamente después de 3 segundos