### PR TITLE
Docker fix/hora del sistema correcta

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
   database:
     image: mariadb
     environment:
+      TZ: "America/Mexico_City"
       MYSQL_ROOT_PASSWORD: "${DB_ROOT_PASS}"
     volumes:
       - db_data:/var/lib/mysql


### PR DESCRIPTION
- Se agregó como variable de entorno la zona horaria de México para tener la hora correcta en el servidor
- Esto corrige el que el servidor registraba mal las fecha en la base de datos.