### PR TITLE
Database: add / archivo de configuración para event_scheduler de MariaDB

### DIFF
--- a/database/event_scheduler.cnf
+++ b/database/event_scheduler.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+event_scheduler=ON

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       MYSQL_ROOT_PASSWORD: "${DB_ROOT_PASS}"
     volumes:
       - db_data:/var/lib/mysql
+      - ./database/event_scheduler.cnf:/etc/mysql/conf.d/event_scheduler.cnf
       - ./database/1_init.sql:/docker-entrypoint-initdb.d/1_init.sql
       - ./database/2_dummydata.sql:/docker-entrypoint-initdb.d/2_dummydata.sql
 volumes:


### PR DESCRIPTION
Se agregó el archivo event_scheduler.cnf en la carpeta database/ con la configuración '[mysqld]\nevent_scheduler=ON' para activar el planificador de eventos de MariaDB de forma persistente.

Se modificó el archivo docker-compose.yml para montar este archivo como volumen en la ruta /etc/mysql/conf.d/event_scheduler.cnf del contenedor database.

Esto resuelve el problema donde el event_scheduler se mantenía en OFF después de reiniciar el contenedor, impidiendo que el evento 'desactivar_encuestas_vencidas' se ejecutara automáticamente. Ahora el scheduler estará activo desde el arranque del contenedor.


Probar levantando el docker con:

`docker-compose down  -v; docker-compose build --no-cache; docker-compose up`



y revisando que no de errores al lenvantar