### PR TITLE
Docker: fix/Zona horaria del contenedor para el servidor web

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - ./uploads:/home/uploads
       - ./app:/var/www/html
     environment:
+      TZ: "America/Mexico_City"
       MYSQL_ROOT_PASSWORD: "${DB_ROOT_PASS}"
   database:
     image: mariadb


### PR DESCRIPTION
Se puede comprobar levantando el docker con 

`docker-compose down  -v; docker-compose build --no-cache; docker-compose up -d`

y en la terminal de cada contenedor **database** y **web** ejecutar el comando 

`date`

para verificar que la hora y fecha es correcta en ambos contenedores