### PR TITLE
fix / event_scheduler ahora se activa mediante command en docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       MYSQL_ROOT_PASSWORD: "${DB_ROOT_PASS}"
   database:
     image: mariadb
+    command: --event-scheduler=ON
     environment:
       TZ: "America/Mexico_City"
       MYSQL_ROOT_PASSWORD: "${DB_ROOT_PASS}"


### PR DESCRIPTION
Se agregó la línea 'command: --event-scheduler=ON' al servicio database en docker-compose.yml.

Esto resuelve el problema donde el event_scheduler de MariaDB permanecía en OFF después de reiniciar el contenedor, especialmente en entornos Windows donde los permisos de archivos montados como volumen causaban que MariaDB ignorara el archivo .cnf.

Se intento una solución con archivo event_scheduler.cnf montado como volumen fallaba en Windows debido a advertencia 'World-writable config file is ignored'.

Esta nueva solución es multiplataforma (Windows, Linux, macOS) y no requiere archivos externos ni manejo de permisos. El parámetro --event-scheduler=ON se pasa directamente al comando de arranque de MariaDB.

Con este cambio, el evento 'desactivar_encuestas_vencidas' se ejecutará automáticamente según su programación, manteniendo el campo Activo de las encuestas actualizado cuando Fecha_fin sea menor a la fecha actual.