### PR TITLE
Database add / columna Contestador en tabla Encuestas y datos de prueba actualizados

### DIFF
--- a/database/1_init.sql
+++ b/database/1_init.sql
@@ -212,6 +212,7 @@ CREATE TABLE `Encuestas` (
   `Descripcion` text DEFAULT NULL,
   `Id_servicio` int(11) NOT NULL,
   `Activo` tinyint(1) DEFAULT 1,
+  `Contestador` tinyint(1) DEFAULT 0,
   `Fecha_inicio` date DEFAULT NULL,
   `Fecha_fin` date DEFAULT NULL,
   `Fecha_registro` datetime DEFAULT current_timestamp(),

--- a/database/2_dummydata.sql
+++ b/database/2_dummydata.sql
@@ -467,15 +467,15 @@ INSERT INTO `Contactos_Alumno` (`Id_contacto`, `Id_alumno`, `Tipo`, `Valor`, `Pr
 -- Volcado de datos para la tabla `Encuestas`
 --
 
-INSERT INTO `Encuestas` (`Id_encuesta`, `Nombre`, `Descripcion`, `Id_servicio`, `Activo`, `Fecha_inicio`, `Fecha_fin`, `Fecha_registro`, `Fecha_modificacion`) VALUES
-(7, 'Evaluación del Servicio Social', 'Encuesta para evaluar la calidad de los formatos, atención y servicios relacionados con el Servicio Social Universitario', 1, 1, '2026-04-14', '2027-04-14', '2026-04-14 08:33:08', NULL),
-(8, 'Evaluación de Practicas Profesionales', 'Encuesta para evaluar la calidad de los formatos, atención y servicios relacionados con las Practicas Profesionales Universitarias', 2, 1, '2026-04-14', '2027-04-14', '2026-04-14 08:33:43', NULL),
-(9, 'Evaluación del Desempeño del Prestador de Servicio Social', 'Encuesta para que la dependencia evalúe el desempeño del alumno durante su Servicio Social', 1, 1, '2026-04-14', '2027-04-14', '2026-04-14 08:34:08', NULL),
-(10, 'Evaluación del Desempeño del Prestador de Practicas Profesionales', 'Encuesta para que la dependencia evalúe el desempeño del alumno durante sus Practicas Profesionales', 2, 1, '2026-04-14', '2027-04-14', '2026-04-14 08:37:42', NULL),
-(11, 'Evaluación del Servicio Social (sin respuestas)', 'Encuesta para evaluar la calidad de los formatos, atención y servicios relacionados con el Servicio Social Universitario', 1, 1, '2026-04-14', '2027-04-14', '2026-04-14 08:33:08', NULL),
-(12, 'Evaluación de Practicas Profesionales (sin respuestas)', 'Encuesta para evaluar la calidad de los formatos, atención y servicios relacionados con las Practicas Profesionales Universitarias', 2, 1, '2026-04-14', '2027-04-14', '2026-04-14 08:33:43', NULL),
-(13, 'Evaluación del Desempeño del Prestador de Servicio Social (sin respuestas)', 'Encuesta para que la dependencia evalúe el desempeño del alumno durante su Servicio Social', 1, 1, '2026-04-14', '2027-04-14', '2026-04-14 08:34:08', NULL),
-(14, 'Evaluación del Desempeño del Prestador de Practicas Profesionales (sin respuestas)', 'Encuesta para que la dependencia evalúe el desempeño del alumno durante sus Practicas Profesionales', 2, 1, '2026-04-14', '2027-04-14', '2026-04-14 08:37:42', NULL);
+INSERT INTO `Encuestas` (`Id_encuesta`, `Nombre`, `Descripcion`, `Id_servicio`, `Activo`, `Contestador`, `Fecha_inicio`, `Fecha_fin`, `Fecha_registro`, `Fecha_modificacion`) VALUES
+(7, 'Evaluación del Servicio Social', 'Encuesta para evaluar la calidad de los formatos, atención y servicios relacionados con el Servicio Social Universitario', 1, 1, 0, '2026-04-14', '2027-04-14', '2026-04-14 08:33:08', NULL),
+(8, 'Evaluación de Practicas Profesionales', 'Encuesta para evaluar la calidad de los formatos, atención y servicios relacionados con las Practicas Profesionales Universitarias', 2, 1, 0, '2026-04-14', '2027-04-14', '2026-04-14 08:33:43', NULL),
+(9, 'Evaluación del Desempeño del Prestador de Servicio Social', 'Encuesta para que la dependencia evalúe el desempeño del alumno durante su Servicio Social', 1, 1, 1, '2026-04-14', '2027-04-14', '2026-04-14 08:34:08', '2026-05-15 01:22:05'),
+(10, 'Evaluación del Desempeño del Prestador de Practicas Profesionales', 'Encuesta para que la dependencia evalúe el desempeño del alumno durante sus Practicas Profesionales', 2, 1, 1, '2026-04-14', '2027-04-14', '2026-04-14 08:37:42', '2026-05-15 01:22:38'),
+(11, 'Evaluación del Servicio Social (sin respuestas)', 'Encuesta para evaluar la calidad de los formatos, atención y servicios relacionados con el Servicio Social Universitario', 1, 1, 0, '2026-04-14', '2027-04-14', '2026-04-14 08:33:08', NULL),
+(12, 'Evaluación de Practicas Profesionales (sin respuestas)', 'Encuesta para evaluar la calidad de los formatos, atención y servicios relacionados con las Practicas Profesionales Universitarias', 2, 1, 0, '2026-04-14', '2027-04-14', '2026-04-14 08:33:43', NULL),
+(13, 'Evaluación del Desempeño del Prestador de Servicio Social (sin respuestas)', 'Encuesta para que la dependencia evalúe el desempeño del alumno durante su Servicio Social', 1, 1, 1, '2026-04-14', '2027-04-14', '2026-04-14 08:34:08', '2026-05-15 01:22:16'),
+(14, 'Evaluación del Desempeño del Prestador de Practicas Profesionales (sin respuestas)', 'Encuesta para que la dependencia evalúe el desempeño del alumno durante sus Practicas Profesionales', 2, 1, 1, '2026-04-14', '2027-04-14', '2026-04-14 08:37:42', '2026-05-15 01:22:21');
 
 
 --


### PR DESCRIPTION
Se agregó la columna Contestador (tinyint, DEFAULT 0) a la tabla Encuestas en 1_init.sql. Esta columna distingue el tipo de contestador de la encuesta: 0 = la encuesta es respondida por el alumno directamente, 1 = la encuesta es respondida por el coordinador/administrador a nombre del alumno. Se actualizaron los datos de prueba en 2_dummydata.sql para incluir el nuevo campo. Las encuestas de evaluación del desempeño del prestador (Id_encuesta 9, 10, 13 y 14) se marcaron con Contestador = 1, ya que corresponden a las que el coordinador/administrador responde por el alumno. Las encuestas de evaluación del servicio (Id_encuesta 7, 8, 11 y 12) se marcaron con Contestador = 0, ya que las responde el alumno directamente. Este cambio es necesario para implementar la lógica de filtrado del Módulo 5, que muestra encuestas distintas según el tipo de usuario en sesión.