### PR TITLE
Docker: update / nginx config to serve uploads directory

### DIFF
--- a/configs_docker/default.conf
+++ b/configs_docker/default.conf
@@ -9,6 +9,10 @@ server {
         try_files $uri $uri/ =404;
     }
 
+    location /uploads/ {
+        alias /home/uploads/;
+    }
+
     location ~ \.php$ {
         include fastcgi_params;
         fastcgi_pass unix:/run/php/php8.4-fpm.sock;


### PR DESCRIPTION
Se agregó el bloque location /uploads/ en configs_docker/default.conf. Este bloque configura Nginx para servir archivos estáticos desde /home/uploads/ cuando se accede a la ruta /uploads/, permitiendo que los archivos subidos sean accesibles directamente desde el navegador.