### PR TITLE
Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,8 @@ services:
       TZ: "America/Mexico_City"
       MYSQL_ROOT_PASSWORD: "${DB_ROOT_PASS}"
     volumes:
-      - db_data:/var/lib/mysql
+      - ./db_data:/var/lib/mysql
       - ./database/1_init.sql:/docker-entrypoint-initdb.d/1_init.sql
       - ./database/2_dummydata.sql:/docker-entrypoint-initdb.d/2_dummydata.sql
 volumes:
-  db_data:
   

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     depends_on:
       - database
     ports:
-      - "8080:80"
+      - "80:80"
     volumes:
       - ./uploads:/home/uploads
       - ./app:/var/www/html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,5 +21,4 @@ services:
       - ./db_data:/var/lib/mysql
       - ./database/1_init.sql:/docker-entrypoint-initdb.d/1_init.sql
       - ./database/2_dummydata.sql:/docker-entrypoint-initdb.d/2_dummydata.sql
-volumes:
   


### PR DESCRIPTION
Se accede a la página por el puerto 80 en vez del 8080 (ya no se tiene que especificar el puerto). Ahora la base de datos está en un almacenamiento montado lo que hace que la base de datos pueda mantenerse aunque el docker se elimine